### PR TITLE
Support custom S3 endpoint + path-style addressing via env

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ If the `CONFIG_FILE` environment variable is not set, the program will fall back
    - `AWS_REGION` - The AWS region.
    - `AWS_ACCESS_KEY_ID` - Your AWS Access Key ID.
    - `AWS_SECRET_ACCESS_KEY` - Your AWS Secret Access Key.
+   - `AWS_ENDPOINT_URL_S3` (optional) - Override the S3 endpoint URL. Honored by the AWS Go SDK and used to point the backend at S3-compatible servers like MinIO or LocalStack. Leave unset for production AWS.
+   - `AWS_S3_FORCE_PATH_STYLE` (optional) - Set to `1` to force path-style addressing (`https://endpoint/bucket/key`). Required when pointing at MinIO or LocalStack, since they don't host buckets as DNS subdomains. Leave unset for production AWS, which uses virtual-hosted style by default.
 
 4. **AWS Keyspaces/Cassandra Configuration**:
 

--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -48,7 +48,7 @@ func main() {
 		if err != nil {
 			log.Fatalf("Error loading AWS configuration: %v", err)
 		}
-		client := s3.NewFromConfig(awsCfg)
+		client := s3.NewFromConfig(awsCfg, S3OptionsFromEnv)
 		awsctx = AwsContext{Client: client, BucketName: aws.String(GetAWSBucketName(appCfg)), Prefix: appCfg.NetworkName, Context: ctx, Log: log}
 
 	}

--- a/src/cmd/itn_uptime_analyzer/main_itn_uptime_analyzer.go
+++ b/src/cmd/itn_uptime_analyzer/main_itn_uptime_analyzer.go
@@ -74,7 +74,7 @@ func main() {
 
     app := new(dg.App)
     app.Log = log
-    client := s3.NewFromConfig(awsCfg)
+    client := s3.NewFromConfig(awsCfg, dg.S3OptionsFromEnv)
 
     awsctx := dg.AwsContext{Client: client, BucketName: aws.String(itn.GetBucketName(appCfg)), Prefix: appCfg.NetworkName, Context: ctx, Log: log}
 

--- a/src/delegation_backend/s3_options.go
+++ b/src/delegation_backend/s3_options.go
@@ -1,0 +1,29 @@
+package delegation_backend
+
+import (
+	"os"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+)
+
+// S3OptionsFromEnv applies environment-driven S3 client options for use with
+// S3-compatible servers like MinIO or LocalStack. Production AWS S3 requires
+// neither variable.
+//
+// AWS_ENDPOINT_URL_S3 overrides the S3 endpoint URL. Native support for this
+// env var was added to aws-sdk-go-v2/config v1.27 (Feb 2024); this backend is
+// pinned to an older version, so we read it explicitly here.
+//
+// AWS_S3_FORCE_PATH_STYLE=1 enables path-style addressing
+// (https://endpoint/bucket/key instead of https://bucket.endpoint/key).
+// MinIO and LocalStack don't host buckets as DNS subdomains, so this is
+// required when pointing the backend at them.
+func S3OptionsFromEnv(o *s3.Options) {
+	if endpoint := os.Getenv("AWS_ENDPOINT_URL_S3"); endpoint != "" {
+		o.BaseEndpoint = aws.String(endpoint)
+	}
+	if os.Getenv("AWS_S3_FORCE_PATH_STYLE") == "1" {
+		o.UsePathStyle = true
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `S3OptionsFromEnv` helper in the `delegation_backend` package
- Wires it into both S3 clients (`delegation_backend` and `itn_uptime_analyzer`)
- Documents two new opt-in env vars in README

## Motivation

Needed by the new [`uptime-service-e2e`](https://github.com/o1-labs/uptime-service-e2e) harness so it can exercise the full S3 write path against MinIO in docker-compose CI without hitting real AWS.

Two env vars added:

- `AWS_ENDPOINT_URL_S3` — overrides the S3 endpoint URL. The AWS Go SDK v2 honors this natively from `config v1.27+` (Feb 2024), but this repo pins `v1.18.37`. Reading it explicitly is far smaller than an SDK upgrade.
- `AWS_S3_FORCE_PATH_STYLE=1` — forces path-style addressing (`https://endpoint/bucket/key` instead of `https://bucket.endpoint/key`). MinIO and LocalStack don't host buckets as DNS subdomains, so this is required when pointing the backend at them.

## Backward compatibility

Both env vars are opt-in. When unset, S3 client behavior is unchanged. Production AWS deployments are not affected.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] Verified end-to-end against MinIO via the `uptime-service-e2e` harness — backend writes to `<bucket>/<network>/blocks/<hash>.dat` and `<bucket>/<network>/submissions/<date>/<ts>-<pubkey>.json` successfully
- [ ] CI unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)