### PR TITLE
Update stale README references after MinaFoundation→o1-labs migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Uptime Service Backend
 
-[![Build](https://github.com/MinaFoundation/uptime-service-backend/actions/workflows/build.yml/badge.svg)](https://github.com/MinaFoundation/uptime-service-backend/actions/workflows/build.yml)
-[![Integration](https://github.com/MinaFoundation/uptime-service-backend/actions/workflows/integration.yml/badge.svg)](https://github.com/MinaFoundation/uptime-service-backend/actions/workflows/integration.yml)
+[![Build](https://github.com/o1-labs/uptime-service-backend/actions/workflows/build.yml/badge.svg)](https://github.com/o1-labs/uptime-service-backend/actions/workflows/build.yml)
+[![Integration](https://github.com/o1-labs/uptime-service-backend/actions/workflows/integration.yml/badge.svg)](https://github.com/o1-labs/uptime-service-backend/actions/workflows/integration.yml)
 
 As part of delegation program, nodes are to upload some proof of their activity. These proofs are to be accumulated and utilized for scoring. This service provides the nodes with a way to submit their data for score calculation.
 
@@ -279,7 +279,7 @@ $ nix-shell
 [nix-shell]$ TAG=uptime-service-backend make docker
 ```
 
-To create the docker image and push it to AWS ECR you can use the [Build and push image to ECR](https://github.com/MinaFoundation/uptime-service-backend/actions/workflows/push-image.yaml) Github action on the target branch or tag.
+To build and publish the Docker image to GitHub Container Registry (`ghcr.io/o1-labs/uptime-service-backend`), use the [Publish](https://github.com/o1-labs/uptime-service-backend/actions/workflows/publish.yaml) GitHub Action — triggered automatically on git tags, or manually via `workflow_dispatch`.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Cleans up three stale references in `README.md` left over from the MinaFoundation→o1-labs migration:

1. **Build badge** — was pointing at `MinaFoundation/uptime-service-backend/actions/workflows/build.yml` (archived); now points at `o1-labs`.
2. **Integration badge** — same issue; updated to `o1-labs`.
3. **"Push to AWS ECR" docs** (line 284) — referenced a workflow `push-image.yaml` that no longer exists, and the wrong registry. Per the in-tree `CLAUDE.md`, the repo migrated from AWS ECR to GHCR; the active publish workflow is `publish.yaml`. Replaced with an accurate description.

## Test plan

- [x] `git diff` shows only the three intended line changes
- [ ] Render the README on the PR view to confirm badges resolve to live status

🤖 Generated with [Claude Code](https://claude.com/claude-code)