### PR TITLE
Expose online endpoint used in ITN testing

### DIFF
--- a/src/cmd/delegation_backend/main_bpu.go
+++ b/src/cmd/delegation_backend/main_bpu.go
@@ -109,6 +109,7 @@ func main() {
 
 	// App other configurations
 	app.Now = func() time.Time { return time.Now() }
+	app.OnlineStorage = NewOnlineStorage(log, app.Now)
 	requestsPerPkHourly := SetRequestsPerPkHourly(log)
 	app.SubmitCounter = NewAttemptCounter(requestsPerPkHourly)
 	log.Infof("Max requests per pk hourly: %v", requestsPerPkHourly)
@@ -118,6 +119,7 @@ func main() {
 		_, _ = rw.Write([]byte("delegation backend service"))
 	})
 	http.Handle("/v1/submit", app.NewSubmitH())
+	http.Handle("/v1/online", app.OnlineStorage)
 
 	// Health check endpoint
 	http.HandleFunc("/health", HealthHandler(func() bool {

--- a/src/delegation_backend/constants.go
+++ b/src/delegation_backend/constants.go
@@ -12,6 +12,7 @@ const MAX_SUBMIT_PAYLOAD_SIZE = 50000000 // max payload size in bytes
 const DELEGATION_BACKEND_LISTEN_TO = ":8080"
 const TIME_DIFF_DELTA time.Duration = -5 * 60 * 1000000000 // -5m
 const WHITELIST_REFRESH_INTERVAL = 10 * 60 * 1000000000    // 10m
+const ONLINE_KEEP_INTERVAL = 20 * time.Minute
 
 var PK_PREFIX = [...]byte{1, 1}
 var SIG_PREFIX = [...]byte{1}

--- a/src/delegation_backend/online.go
+++ b/src/delegation_backend/online.go
@@ -1,0 +1,79 @@
+package delegation_backend
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+type OnlineRecord struct {
+	RemoteAddr         string `json:"remote_addr"`
+	Submitter          string `json:"submitter"`
+	GraphqlControlPort int    `json:"graphql_control_port,omitempty"`
+}
+
+type onlineEntry struct {
+	record      OnlineRecord
+	submittedAt time.Time
+}
+
+type OnlineStorage struct {
+	mu   sync.Mutex
+	data map[string]onlineEntry
+	now  nowFunc
+	log  *logging.ZapEventLogger
+}
+
+func NewOnlineStorage(log *logging.ZapEventLogger, now nowFunc) *OnlineStorage {
+	return &OnlineStorage{
+		data: make(map[string]onlineEntry),
+		now:  now,
+		log:  log,
+	}
+}
+
+func (storage *OnlineStorage) Record(record OnlineRecord, submittedAt time.Time) {
+	storage.mu.Lock()
+	defer storage.mu.Unlock()
+	storage.data[record.Submitter] = onlineEntry{
+		record:      record,
+		submittedAt: submittedAt,
+	}
+}
+
+func (storage *OnlineStorage) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	result := storage.recentRecords()
+	bs, err := json.Marshal(result)
+	if err != nil {
+		storage.log.Errorf("Error while marshaling online response: %v", err)
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.Copy(w, bytes.NewReader([]byte(`{"error":"Unexpected server error"}`)))
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_, err = io.Copy(w, bytes.NewReader(bs))
+	if err != nil {
+		storage.log.Debugf("Error while responding with /v1/online payload: %v", err)
+	}
+}
+
+func (storage *OnlineStorage) recentRecords() []OnlineRecord {
+	storage.mu.Lock()
+	defer storage.mu.Unlock()
+
+	earliest := storage.now().Add(-ONLINE_KEEP_INTERVAL)
+	result := make([]OnlineRecord, 0, len(storage.data))
+	for submitter, entry := range storage.data {
+		if entry.submittedAt.After(earliest) {
+			result = append(result, entry.record)
+			continue
+		}
+		delete(storage.data, submitter)
+	}
+	return result
+}

--- a/src/delegation_backend/online_test.go
+++ b/src/delegation_backend/online_test.go
@@ -1,0 +1,67 @@
+package delegation_backend
+
+import (
+	"encoding/json"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	logging "github.com/ipfs/go-log/v2"
+)
+
+func TestOnlineStorageServeHTTP(t *testing.T) {
+	log := logging.Logger("delegation backend online test")
+	now := time.Date(2026, 5, 28, 12, 0, 0, 0, time.UTC)
+	storage := NewOnlineStorage(log, func() time.Time { return now })
+	storage.Record(OnlineRecord{
+		RemoteAddr:         "10.0.0.2",
+		Submitter:          "B62valid",
+		GraphqlControlPort: 10001,
+	}, now.Add(-5*time.Minute))
+	storage.Record(OnlineRecord{
+		RemoteAddr:         "10.0.0.3",
+		Submitter:          "B62expired",
+		GraphqlControlPort: 10002,
+	}, now.Add(-ONLINE_KEEP_INTERVAL-time.Second))
+
+	req := httptest.NewRequest("GET", "/v1/online", nil)
+	rr := httptest.NewRecorder()
+	storage.ServeHTTP(rr, req)
+
+	if rr.Code != 200 {
+		t.Fatalf("unexpected status code: got %d want 200", rr.Code)
+	}
+
+	var records []OnlineRecord
+	if err := json.Unmarshal(rr.Body.Bytes(), &records); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(records) != 1 {
+		t.Fatalf("unexpected number of online records: got %d want 1", len(records))
+	}
+	if records[0].Submitter != "B62valid" || records[0].RemoteAddr != "10.0.0.2" || records[0].GraphqlControlPort != 10001 {
+		t.Fatalf("unexpected response payload: %+v", records[0])
+	}
+}
+
+func TestNormalizeRemoteAddr(t *testing.T) {
+	testCases := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{name: "host port", input: "192.0.2.1:1234", want: "192.0.2.1"},
+		{name: "xff first value", input: "10.0.0.1:1234, 10.0.0.2", want: "10.0.0.1"},
+		{name: "plain ip", input: "5.189.147.209", want: "5.189.147.209"},
+		{name: "ipv6 host port", input: "[2001:db8::1]:8080", want: "2001:db8::1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := normalizeRemoteAddr(tc.input)
+			if got != tc.want {
+				t.Fatalf("unexpected normalized address: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/delegation_backend/submit.go
+++ b/src/delegation_backend/submit.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -112,6 +113,7 @@ type App struct {
 	WhitelistDisabled       bool
 	VerifySignatureDisabled bool
 	NetworkId               uint8
+	OnlineStorage           *OnlineStorage
 	Save                    func(ObjectsToSave)
 	Now                     nowFunc
 	IsReady                 bool
@@ -247,6 +249,13 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	h.app.Log.Infof("Saving submission for submitter %s: block_hash=%s meta_path=%s block_path=%s", req.Submitter.String(), blockHash, ps.Meta, ps.Block)
 	h.app.Save(toSave)
+	if h.app.OnlineStorage != nil {
+		h.app.OnlineStorage.Record(OnlineRecord{
+			RemoteAddr:         normalizeRemoteAddr(remoteAddr),
+			Submitter:          req.Submitter.String(),
+			GraphqlControlPort: req.Data.GraphqlControlPort,
+		}, submittedAt)
+	}
 
 	_, err2 := io.Copy(w, bytes.NewReader([]byte("{\"status\":\"ok\"}")))
 	if err2 != nil {
@@ -260,4 +269,22 @@ func (app *App) NewSubmitH() *SubmitH {
 	s := new(SubmitH)
 	s.app = app
 	return s
+}
+
+func normalizeRemoteAddr(remoteAddr string) string {
+	if strings.Contains(remoteAddr, ",") {
+		remoteAddr = strings.TrimSpace(strings.Split(remoteAddr, ",")[0])
+	}
+	host, _, err := net.SplitHostPort(remoteAddr)
+	if err == nil {
+		return host
+	}
+	if ip := net.ParseIP(remoteAddr); ip != nil {
+		return remoteAddr
+	}
+	if strings.Count(remoteAddr, ":") == 1 {
+		parts := strings.SplitN(remoteAddr, ":", 2)
+		return parts[0]
+	}
+	return remoteAddr
 }

--- a/src/delegation_backend/submit_test.go
+++ b/src/delegation_backend/submit_test.go
@@ -59,6 +59,7 @@ func testSubmitH(maxAttempt int, initWl Whitelist) (*ObjectsToSave, *SubmitH, *t
 	counter, tm := newTestAttemptCounter(1)
 	app.SubmitCounter = counter
 	app.Now = tm.Now
+	app.OnlineStorage = NewOnlineStorage(log, app.Now)
 	wlMvar := new(WhitelistMVar)
 	wlMvar.Replace(&initWl)
 	app.Whitelist = wlMvar
@@ -203,6 +204,16 @@ func TestSuccess(t *testing.T) {
 			!bytes.Equal((*objs)[paths.Block], req.Data.Block.data) {
 			t.Logf("Content check failed for %s", f)
 			t.FailNow()
+		}
+		online := sh.app.OnlineStorage.recentRecords()
+		if len(online) != 1 {
+			t.Fatalf("expected one online record for %s, got %d", f, len(online))
+		}
+		if online[0].Submitter != req.Submitter.String() {
+			t.Fatalf("unexpected online submitter for %s: got %s want %s", f, online[0].Submitter, req.Submitter.String())
+		}
+		if online[0].RemoteAddr != "192.0.2.1" {
+			t.Fatalf("unexpected online remote_addr for %s: got %s want %s", f, online[0].RemoteAddr, "192.0.2.1")
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- expose the  endpoint in the delegation backend
- record recent submitter connectivity details from 
- keep online records for a bounded interval and cover the new behavior with tests

## Motivation
Expose the same endpoint that the alternative implementation used in ITN testing.

## Testing
- not run (per request)