### PR TITLE
Fix remote IP resolution for online endpoint

### DIFF
--- a/src/delegation_backend/online_test.go
+++ b/src/delegation_backend/online_test.go
@@ -65,3 +65,31 @@ func TestNormalizeRemoteAddr(t *testing.T) {
 		})
 	}
 }
+
+func TestRequestRemoteAddr(t *testing.T) {
+	testCases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		want       string
+	}{
+		{name: "no xff falls back to remote addr", remoteAddr: "192.0.2.1:1234", want: "192.0.2.1:1234"},
+		{name: "uses public xff hop", remoteAddr: "127.0.0.1:9999", xff: "127.0.0.1, 203.0.113.9", want: "203.0.113.9"},
+		{name: "uses first public xff after private hops", remoteAddr: "127.0.0.1:9999", xff: "10.0.0.4, 172.16.0.8, 198.51.100.7", want: "198.51.100.7"},
+		{name: "falls back to first valid xff when no public hop", remoteAddr: "127.0.0.1:9999", xff: "127.0.0.1, 10.0.0.4", want: "127.0.0.1"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			req := httptest.NewRequest("POST", "/v1/submit", nil)
+			req.RemoteAddr = tc.remoteAddr
+			if tc.xff != "" {
+				req.Header.Set("X-Forwarded-For", tc.xff)
+			}
+			got := requestRemoteAddr(req)
+			if got != tc.want {
+				t.Fatalf("unexpected request remote addr: got %q want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/src/delegation_backend/submit.go
+++ b/src/delegation_backend/submit.go
@@ -229,11 +229,7 @@ func (h *SubmitH) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	blockHash := req.GetBlockDataHash()
 	ps := makePaths(submittedAt, blockHash, req.Submitter)
 
-	remoteAddr := r.Header.Get("X-Forwarded-For")
-	if remoteAddr == "" {
-		// If there is no X-Forwarded-For header, use the remote address
-		remoteAddr = r.RemoteAddr
-	}
+	remoteAddr := requestRemoteAddr(r)
 
 	metaBytes, err1 := req.MakeMetaToBeSaved(remoteAddr)
 	if err1 != nil {
@@ -271,6 +267,33 @@ func (app *App) NewSubmitH() *SubmitH {
 	return s
 }
 
+func requestRemoteAddr(r *http.Request) string {
+	forwardedFor := r.Header.Get("X-Forwarded-For")
+	if forwardedFor == "" {
+		return r.RemoteAddr
+	}
+
+	candidates := strings.Split(forwardedFor, ",")
+	firstValid := ""
+	for _, candidate := range candidates {
+		normalized := normalizeRemoteAddr(strings.TrimSpace(candidate))
+		if normalized == "" {
+			continue
+		}
+		if firstValid == "" {
+			firstValid = normalized
+		}
+		ip := net.ParseIP(normalized)
+		if ip != nil && isPublicIP(ip) {
+			return normalized
+		}
+	}
+	if firstValid != "" {
+		return firstValid
+	}
+	return r.RemoteAddr
+}
+
 func normalizeRemoteAddr(remoteAddr string) string {
 	if strings.Contains(remoteAddr, ",") {
 		remoteAddr = strings.TrimSpace(strings.Split(remoteAddr, ",")[0])
@@ -287,4 +310,13 @@ func normalizeRemoteAddr(remoteAddr string) string {
 		return parts[0]
 	}
 	return remoteAddr
+}
+
+func isPublicIP(ip net.IP) bool {
+	return !ip.IsLoopback() &&
+		!ip.IsPrivate() &&
+		!ip.IsLinkLocalMulticast() &&
+		!ip.IsLinkLocalUnicast() &&
+		!ip.IsMulticast() &&
+		!ip.IsUnspecified()
 }


### PR DESCRIPTION
Summary
- stop trusting the first X-Forwarded-For hop when it is a proxy-local/private address
- pick the first public forwarded IP when present, otherwise fall back predictably
- add coverage for forwarded address chains and fallback behavior

Context
The /v1/online endpoint introduced in commit ddc393bbff8895847c63465f78c4be07df06125a was reporting 127.0.0.1 for many submitters because the submit path stored a normalized address derived from X-Forwarded-For without filtering out proxy-local hops.

Verification
- added unit coverage for requestRemoteAddr
- attempted go test ./delegation_backend/..., but local verification is blocked in this environment because src/delegation_backend/signer.go requires crypto.h from the signer build artifacts